### PR TITLE
qq/get_album(): Fix data['data']['list'] === None

### DIFF
--- a/listen1/replay/qq.py
+++ b/listen1/replay/qq.py
@@ -158,7 +158,7 @@ def get_album(album_id):
         id='qqalbum_' + str(album_id))
 
     result = []
-    for song in data['data']['list']:
+    for song in data['data']['list'] or []:
         result.append(_convert_song(song))
     return dict(tracks=result, info=info)
 


### PR DESCRIPTION
Replaces #11.

/album?album_id=qqalbum_0040aH1l3ykBRh

```
Traceback (most recent call last):
  File "site-packages/tornado/web.py", line 1443, in _execute
  File "listen1/handlers/player.py", line 45, in get
  File "listen1/replay/qq.py", line 161, in get_album
TypeError: 'NoneType' object is not iterable
```

`{"info": {"cover_img_url": "http://imgcache.qq.com/music/photo/mid_album_300/R/h/0040aH1l3ykBRh.jpg", "id": "qqalbum_0040aH1l3ykBRh", "title": "\u6211\u7684\u5c11\u5973\u65f6\u4ee3 \u7535\u5f71\u539f\u58f0\u5e26"}, "status": "1", "tracks": [], "is_mine": "0"}`